### PR TITLE
Changed the _get_blocks() method of block.Blocks()

### DIFF
--- a/picraft/block.py
+++ b/picraft/block.py
@@ -466,9 +466,9 @@ class Blocks(object):
 
     def _get_blocks(self, vrange):
         return [
-            Block.from_string('%d,0' % int(i))
+            Block.from_string(i.replace("|", ",", 1)+",0"*("|" not in i))
             for i in self._connection.transact(
-                'world.getBlocks(%d,%d,%d,%d,%d,%d)' % (
+                'world.getBlocksWithData(%d,%d,%d,%d,%d,%d)' % (
                 vrange.start.x, vrange.start.y, vrange.start.z,
                 vrange.stop.x - vrange.step.x,
                 vrange.stop.y - vrange.step.y,

--- a/picraft/block.py
+++ b/picraft/block.py
@@ -466,14 +466,14 @@ class Blocks(object):
 
     def _get_blocks(self, vrange):
         return [
-            Block.from_string(i.replace("|", ",", 1)+",0"*("|" not in i))
+            Block.from_string(i)
             for i in self._connection.transact(
                 'world.getBlocksWithData(%d,%d,%d,%d,%d,%d)' % (
                 vrange.start.x, vrange.start.y, vrange.start.z,
                 vrange.stop.x - vrange.step.x,
                 vrange.stop.y - vrange.step.y,
                 vrange.stop.z - vrange.step.z)
-                ).split(',')
+                ).split('|')
             ]
 
     def _get_block_loop(self, vrange):


### PR DESCRIPTION
A multi-block vector slice of World().blocks now properly returns block data instead of inevitably setting it to 0. Tested with Raspberry Jam.